### PR TITLE
Fix funky indenting in an array literal

### DIFF
--- a/check_whitespace.c
+++ b/check_whitespace.c
@@ -74,13 +74,14 @@ int main() {
   int i;
   int NUM_STRINGS = 7;
   // Makes an array of 7 string constants for testing.
-  char* strings[] = {  "Morris", 
-		       "  stuff", 
-		       "Minnesota", 
-		       "nonsense  ", 
-		       "USA", 
-		       "   ", 
-		       "     silliness    "
+  char* strings[] = {
+    "Morris",
+    "  stuff",
+    "Minnesota",
+    "nonsense  ",
+    "USA",
+    "   ",
+    "     silliness    "
   };
 
   for (i=0; i<NUM_STRINGS; ++i) {


### PR DESCRIPTION
The array had been indented with a mixture of spaces and tabs. This
commit changes it to just use spaces, which is consistent with the
surrounding code. 🙂